### PR TITLE
feat: upgrade @octoreport/core to v0.1.3 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1421,9 +1421,9 @@
       }
     },
     "node_modules/@octoreport/core": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@octoreport/core/-/core-0.1.1.tgz",
-      "integrity": "sha512-qwhmDXqJCVrQVTaOLhS4RCvTDT1p6Nmdp4owXbNClP9ERXAo92XyH5chlU6hEG39tMOKMfgQQDcwu8JoNg/1QQ==",
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@octoreport/core/-/core-0.1.3.tgz",
+      "integrity": "sha512-iuLo0MXU1yVPQL4CLINWdN5GzMf9X83X4+o/t9mUnmvPkPEg688jr3DXnw9alJSdHoRt9k6BEf6Xhv5yUfe/2A==",
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-oauth-device": "^8.0.1",

--- a/src/commands/all/handler.ts
+++ b/src/commands/all/handler.ts
@@ -1,4 +1,4 @@
-import { getUserPRListByCreationAndParticipation } from '@octoreport/core';
+import { getUserPRActivityListInPeriod } from '@octoreport/core';
 import chalk from 'chalk';
 
 import { printBox, TableConfig, renderTable } from '../../features/ui';
@@ -29,7 +29,7 @@ export const COMMON_TABLE_CONFIG: TableConfig[] = [
 export async function handleAllCommand(format: Format) {
   await withCommandContext(async (answers, githubToken, username, spinner) => {
     const { username: answeredUsername, repository, startDate, endDate, targetBranch } = answers;
-    const result = await getUserPRListByCreationAndParticipation({
+    const result = await getUserPRActivityListInPeriod({
       githubToken,
       username: answeredUsername || username,
       repository,
@@ -60,28 +60,26 @@ export async function handleAllCommand(format: Format) {
         { width: 15, title: 'Created At', key: 'createdAt' },
         { width: 15, title: 'Merged At', key: 'mergedAt' },
       ];
-      renderTable(userCreatedPRTableConfig, result.userCreatedPRList);
+      renderTable(userCreatedPRTableConfig, result.created);
 
       const userParticipatedPRTableConfig: TableConfig[] = [
         ...COMMON_TABLE_CONFIG,
         { width: 15, title: 'Is Reviewed By Me', key: 'reviewers' },
-        { width: 15, title: 'Is Commented By Me', key: 'comments' },
+        { width: 15, title: 'Is Commented By Me', key: 'commenters' },
       ];
       renderTable(
         userParticipatedPRTableConfig,
-        result.userParticipatedPRList.map((pr) => ({
+        result.participated.map((pr) => ({
           ...pr,
-          reviewers: [pr.reviewers.includes(username || answeredUsername) ? '✅' : '❌'],
-          comments: [
-            pr.comments && pr.comments.includes(username || answeredUsername) ? '✅' : '❌',
-          ],
+          reviewers: [pr.reviewers?.includes(username || answeredUsername) ? '✅' : '❌'],
+          commenters: [pr.commenters?.includes(username || answeredUsername) ? '✅' : '❌'],
         })),
       );
     } else if (format === 'json') {
       console.log(JSON.stringify(result, null, 2));
     } else {
-      console.log('\n🐙📊 User Created PRs:\n', result.userCreatedPRList);
-      console.log('\n🐙📊 User Participated PRs:\n', result.userParticipatedPRList);
+      console.log('\n🐙📊 User Created PRs:\n', result.created);
+      console.log('\n🐙📊 User Participated PRs:\n', result.participated);
     }
   });
 }

--- a/src/commands/withCommandContext.ts
+++ b/src/commands/withCommandContext.ts
@@ -24,10 +24,18 @@ export async function withCommandContext<T>(
   try {
     await command(answers, githubToken, username, spinner);
   } catch (error) {
+    // 이미 처리된 오류인지 확인 (spinner가 이미 fail 상태인지)
+    if (!spinner.isSpinning && spinner.text.includes('❌')) {
+      // 이미 처리된 오류는 추가 처리하지 않음
+      return;
+    }
+
     const errorMessage = error instanceof Error && error.message ? error.message : 'Unknown error';
     spinner.fail(`❌ Failed to execute command: ${errorMessage}. Please try again.`);
     console.error(error);
   } finally {
-    spinner.stop();
+    if (spinner.isSpinning) {
+      spinner.stop();
+    }
   }
 }

--- a/src/features/ui/components/tables.ts
+++ b/src/features/ui/components/tables.ts
@@ -8,7 +8,7 @@ export interface TableConfig {
   key: keyof PR;
 }
 
-export type TablePRData = Omit<PR, 'labels' | 'reviewers' | 'comments'>;
+export type TablePRData = Omit<PR, 'labels' | 'reviewers' | 'commenters'>;
 
 export interface TableData {
   data: PR[];


### PR DESCRIPTION
## Changes

> Write about the features you've implemented or modified.
- This PR updates the CLI to work with the latest version of `@octoreport/core` (v0.1.3) and includes several improvements to error handling and API integration.

- **Dependency Update**: Upgrade `@octoreport/core` from v0.1.1 to v0.1.3
- **API Migration**: Replace deprecated `getUserPRListByCreationAndParticipation` with `getUserPRActivityListInPeriod`
- **Response Structure Update**: Update to new API response format:
  - `userCreatedPRList` → `created`
  - `userParticipatedPRList` → `participated`
- **Property Name Fixes**: 
  - `comments` → `commenters` for consistency
  - Add null-safe checks for `reviewers` and `commenters` arrays

## Check List

> Please describe any areas you'd like the reviewer to pay special attention to.
> [e.g] Code structure, naming, implementation

- [ ]

## Test Step

> Please provide the environment variables to test this PR, and the steps for the executable script.
> It helps reviewers review code faster.

## Screenshots

> Please attach screenshots of the implementation and modified functionality.
> It helps reviewers quickly understand where to focus their attention.
